### PR TITLE
Fix non-strict syntax by removing global return

### DIFF
--- a/test/shams/core-js.js
+++ b/test/shams/core-js.js
@@ -5,24 +5,23 @@ var test = require('tape');
 if (typeof Symbol === 'function' && typeof Symbol() === 'symbol') {
 	test('has native Symbol support', function (t) {
 		t.equal(typeof Symbol, 'function');
-		t.equal(typeof Symbol(), 'symbol');
-		t.end();
-	});
-	return;
+    t.equal(typeof Symbol(), 'symbol');
+    t.end();
+  });
+} else {
+  var hasSymbols = require('../../shams');
+
+  test('polyfilled Symbols', function (t) {
+    /* eslint-disable global-require */
+    t.equal(hasSymbols(), false, 'hasSymbols is false before polyfilling');
+    require('core-js/fn/symbol');
+    require('core-js/fn/symbol/to-string-tag');
+
+    require('../tests')(t);
+
+    var hasSymbolsAfter = hasSymbols();
+    t.equal(hasSymbolsAfter, true, 'hasSymbols is true after polyfilling');
+    /* eslint-enable global-require */
+    t.end();
+  });
 }
-
-var hasSymbols = require('../../shams');
-
-test('polyfilled Symbols', function (t) {
-	/* eslint-disable global-require */
-	t.equal(hasSymbols(), false, 'hasSymbols is false before polyfilling');
-	require('core-js/fn/symbol');
-	require('core-js/fn/symbol/to-string-tag');
-
-	require('../tests')(t);
-
-	var hasSymbolsAfter = hasSymbols();
-	t.equal(hasSymbolsAfter, true, 'hasSymbols is true after polyfilling');
-	/* eslint-enable global-require */
-	t.end();
-});

--- a/test/shams/get-own-property-symbols.js
+++ b/test/shams/get-own-property-symbols.js
@@ -3,26 +3,25 @@
 var test = require('tape');
 
 if (typeof Symbol === 'function' && typeof Symbol() === 'symbol') {
-	test('has native Symbol support', function (t) {
-		t.equal(typeof Symbol, 'function');
-		t.equal(typeof Symbol(), 'symbol');
-		t.end();
-	});
-	return;
+  test('has native Symbol support', function (t) {
+    t.equal(typeof Symbol, 'function');
+    t.equal(typeof Symbol(), 'symbol');
+    t.end();
+  });
+} else {
+  var hasSymbols = require('../../shams');
+
+  test('polyfilled Symbols', function (t) {
+    /* eslint-disable global-require */
+    t.equal(hasSymbols(), false, 'hasSymbols is false before polyfilling');
+
+    require('get-own-property-symbols');
+
+    require('../tests')(t);
+
+    var hasSymbolsAfter = hasSymbols();
+    t.equal(hasSymbolsAfter, true, 'hasSymbols is true after polyfilling');
+    /* eslint-enable global-require */
+    t.end();
+  });
 }
-
-var hasSymbols = require('../../shams');
-
-test('polyfilled Symbols', function (t) {
-	/* eslint-disable global-require */
-	t.equal(hasSymbols(), false, 'hasSymbols is false before polyfilling');
-
-	require('get-own-property-symbols');
-
-	require('../tests')(t);
-
-	var hasSymbolsAfter = hasSymbols();
-	t.equal(hasSymbolsAfter, true, 'hasSymbols is true after polyfilling');
-	/* eslint-enable global-require */
-	t.end();
-});


### PR DESCRIPTION
This resolves an issue where the module wasn't able to be parsed in strict mode.

See: ssbc/ssb-server#683